### PR TITLE
Fix invalid namespace

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "promostandards/ruby/client"
+require "promostandards_ruby_client"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/bin/setup
+++ b/bin/setup
@@ -4,5 +4,3 @@ IFS=$'\n\t'
 set -vx
 
 bundle install
-
-# Do any other automated setup that you need to do here

--- a/lib/promostandards_ruby_client.rb
+++ b/lib/promostandards_ruby_client.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-# PromoStandardsRubyClient is an unofficial Ruby client for interacting with
+# PromostandardsRubyClient is an unofficial Ruby client for interacting with
 # PromoStandards API services, providing a flexible configuration interface
 # for accessing services such as Product Data, Media Content, and Pricing.
 #
 # This gem allows users to set up a client with options for service URL and
 # logging, making it easy to integrate PromoStandards functionality into
 # Ruby applications.
-module PromoStandardsRubyClient
+module PromostandardsRubyClient
   require_relative "promostandards_ruby_client/version"
   require_relative "promostandards_ruby_client/client"
   require_relative "promostandards_ruby_client/configuration"

--- a/lib/promostandards_ruby_client/services/product_pricing_and_configuration.rb
+++ b/lib/promostandards_ruby_client/services/product_pricing_and_configuration.rb
@@ -13,7 +13,7 @@ module PromostandardsRubyClient
     # == Usage
     #
     #   # Example call to get product configuration and pricing
-    #   client = PromoStandardsRubyClient::Client.new
+    #   client = PromostandardsRubyClient::Client.new
     #   response = client.get_configuration_and_pricing("G500")
     #
     # == Methods


### PR DESCRIPTION
Correct namespace is PromostandardsRubyClient not
PromoStandardsRubyClient.
